### PR TITLE
Avoid trying to remove . and ..

### DIFF
--- a/src/jepsen/local_fs/db/dir.clj
+++ b/src/jepsen/local_fs/db/dir.clj
@@ -15,4 +15,4 @@
       (sh :mkdir :-p dir))
 
     (teardown! [this test node]
-      (sh :bash :-c (str "rm -rf " dir "/* " dir "/.*")))))
+      (sh :bash :-c (str "rm -rf " dir "/* " dir "/..?*" dir "/.[!.]*")))))


### PR DESCRIPTION
This prevents errors of the form:

```
rm: refusing to remove '.' or '..' directory: skipping 'data/.'
rm: refusing to remove '.' or '..' directory: skipping 'data/..'
```

Previously these prevented `lein run quickcheck` from running on
Linux.